### PR TITLE
feat(theme): add light-blue UI theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -114,6 +114,55 @@
   --widget-header: oklch(0.22 0 0);
 }
 
+/* ────────────────────────────────────────────────────────────
+   BLUE  💧 palette – NEW
+   “blue” theme is a gentle light-blue UI variant.
+   ──────────────────────────────────────────────────────────── */
+.blue {
+  --background: oklch(0.98 0.02 225); /* #f0f8ff */
+  --foreground: oklch(0.18 0.01 240); /* dark slate */
+  --card: oklch(1 0 0);
+  --card-foreground: var(--foreground);
+  --popover: oklch(1 0 0);
+  --popover-foreground: var(--foreground);
+
+  --primary: oklch(0.46 0.13 235); /* vibrant blue buttons */
+  --primary-foreground: oklch(0.985 0 0); /* white text */
+
+  --secondary: oklch(0.95 0.02 225); /* pale blue tint */
+  --secondary-foreground: var(--foreground);
+
+  --muted: oklch(0.95 0.02 225);
+  --muted-foreground: oklch(0.46 0.07 235);
+
+  --accent: oklch(0.92 0.03 215);
+  --accent-foreground: var(--foreground);
+
+  --destructive: oklch(0.62 0.18 27.3); /* keep existing red */
+
+  --border: oklch(0.9 0.01 225);
+  --input: oklch(0.9 0.01 225);
+  --ring: oklch(0.55 0.08 235);
+
+  /* Charts & sidebar */
+  --chart-1: oklch(0.66 0.18 235);
+  --chart-2: oklch(0.57 0.12 205);
+  --chart-3: oklch(0.46 0.13 235);
+  --chart-4: oklch(0.78 0.17 215);
+  --chart-5: oklch(0.72 0.16 195);
+
+  --sidebar: oklch(0.96 0.02 225);
+  --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--accent);
+  --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  --widget-header: oklch(0.93 0.02 225);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -9,14 +9,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
-import { Sun, Moon, Laptop } from "lucide-react";
+import { Sun, Moon, Laptop, Droplet } from "lucide-react";
 
 /**
- * Theme toggle with icons.
- *
- * • Topbar button shows the icon for the current theme (light ☀️, dark 🌙, or system 💻).
- * • Dropdown items include matching icons.
- * • During SSR hydration we render a placeholder icon (Sun) to avoid mismatches.
+ * Theme toggle with icons (light ☀️, dark 🌙, blue 💧, system 💻).
+ * Uses a placeholder icon during SSR hydration.
  */
 export default function ModeToggle() {
   const { theme, setTheme } = useTheme();
@@ -25,10 +22,12 @@ export default function ModeToggle() {
 
   // Decide which icon to show in the button
   const CurrentIcon = () => {
-    if (!mounted) return <Sun className="h-4 w-4" />; // placeholder while hydrating
+    if (!mounted) return <Sun className="h-4 w-4" />;
     switch (theme) {
       case "dark":
         return <Moon className="h-4 w-4" />;
+      case "blue":
+        return <Droplet className="h-4 w-4" />;
       case "system":
         return <Laptop className="h-4 w-4" />;
       default:
@@ -39,7 +38,6 @@ export default function ModeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        {/* icon-only button; keeps size consistent with other icon buttons */}
         <Button variant="outline" size="icon" aria-label="Toggle theme">
           <CurrentIcon />
         </Button>
@@ -52,6 +50,10 @@ export default function ModeToggle() {
         <DropdownMenuItem onClick={() => setTheme("dark")}>
           <Moon className="mr-2 h-4 w-4" />
           Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("blue")}>
+          <Droplet className="mr-2 h-4 w-4" />
+          Blue
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("system")}>
           <Laptop className="mr-2 h-4 w-4" />

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -3,6 +3,10 @@
 import * as React from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 
+/**
+ * Wraps the app with next-themes.
+ * Adds a custom “blue” theme on top of light / dark.
+ */
 export default function ThemeProvider({
   children,
 }: {
@@ -13,6 +17,8 @@ export default function ThemeProvider({
       attribute="class"
       defaultTheme="system"
       enableSystem
+      /** Limit to the themes we explicitly style */
+      themes={["light", "dark", "blue"]}
       disableTransitionOnChange
     >
       {children}


### PR DESCRIPTION
### Description
Adds a new **light-blue (“blue”) theme** alongside light/dark/system.

### Key Changes
- `globals.css`: blue palette variables.
- `theme-provider.tsx`: registers `"blue"` in `themes` prop.
- `mode-toggle.tsx`: dropdown item + icon handling.

### How to Test
1. Checkout `feat/blue-theme` locally or use GitHub Preview.  
2. In the UI, open the theme toggle → choose **Blue**.  
3. Verify background, text, buttons, sidebar, and charts switch to the light-blue palette.  
4. Switch between Light, Dark, System to ensure old themes still work.  