### PR TITLE
feat(nav): add public Education page with placeholder resources

### DIFF
--- a/src/app/education/page.tsx
+++ b/src/app/education/page.tsx
@@ -1,0 +1,45 @@
+export const metadata = {
+  title: "Education | Next Standup",
+  description: "Curated resources for continuous learning.",
+};
+
+export default function EducationPage() {
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 p-4">
+      <h1 className="text-2xl font-semibold">Education</h1>
+      <p className="text-muted-foreground">
+        A curated list of external resources to sharpen your skills. We’ll keep
+        adding more links over time.
+      </p>
+
+      <section className="space-y-3">
+        <Resource
+          href="https://nextjs.org/learn"
+          label="Next.js Official Tutorial"
+        />
+        <Resource
+          href="https://tailwindcss.com/docs"
+          label="Tailwind CSS Documentation"
+        />
+        <Resource href="https://supabase.com/docs" label="Supabase Docs" />
+        <Resource
+          href="https://www.typescriptlang.org/docs/"
+          label="TypeScript Handbook"
+        />
+      </section>
+    </main>
+  );
+}
+
+function Resource({ href, label }: { href: string; label: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block rounded border p-3 hover:bg-muted/50"
+    >
+      {label}
+    </a>
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Sparkles,
   User as UserIcon,
   Cpu,
+  BookOpen, // NEW
 } from "lucide-react";
 
 type Props = { signedIn: boolean };
@@ -35,13 +36,14 @@ export default function AppSidebar({ signedIn }: Props) {
           { label: "Profile", href: "/profile", icon: UserIcon },
         ]
       : []),
+    /* Public link (always visible) ------------------------------------ */
+    { label: "Education", href: "/education", icon: BookOpen },
   ];
 
   return (
     <div className="h-full flex flex-col">
       {/* Brand row */}
       <div className="p-4 flex items-center gap-2">
-        {/* colorful engineering icon */}
         <Cpu
           size={20}
           strokeWidth={2}

--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -15,14 +15,14 @@ import {
 /* prettier-ignore */
 function labelFor(seg: string) {
   switch (seg) {
-    case "standups":       return "Stand-up Notes";
-    case "users":          return "User List";
-    case "github-prs":     return "GitHub PRs";
-    case "summaries":      return "Summaries";
-    case "ai-summaries":   return "AI Summaries";
-    case "profile":        return "Profile";
+    case "standups":     return "Stand-up Notes";
+    case "users":        return "User List";
+    case "github-prs":   return "GitHub PRs";
+    case "summaries":    return "Summaries";
+    case "ai-summaries": return "AI Summaries";
+    case "profile":      return "Profile";
+    case "education":    return "Education";       // NEW
     default:
-      /* Title-case kebab segments as a graceful fallback, e.g. "foo-bar" → "Foo Bar" */
       return seg
         .split("-")
         .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
@@ -34,7 +34,6 @@ export default function Breadcrumbs() {
   const pathname = usePathname() || "/";
   const segments = pathname.split("/").filter(Boolean);
 
-  // Build breadcrumb items: Home + each cumulative segment
   const items = [{ href: "/", label: "Home" }].concat(
     segments.map((seg, idx) => ({
       href: "/" + segments.slice(0, idx + 1).join("/"),


### PR DESCRIPTION
### Description
Adds a public **Education** section, updates sidebar & breadcrumbs, and scaffolds `/education` page.

### Key Changes
- `app-sidebar.tsx`: appends Education link (BookOpen icon).
- `breadcrumbs.tsx`: label mapping for “education”.
- `app/education/page.tsx`: placeholder resource list.

### How to Test
1. Run dev server, open sidebar → “Education” appears at bottom (visible signed-in or not).
2. Click link → `/education` loads with placeholder links.
3. Breadcrumb shows “Home / Education”.