### PR TITLE
style(hero): make padding configurable; use compact spacing on Educat…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2247,7 +2247,7 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2257,7 +2257,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -3372,7 +3372,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/src/app/education/page.tsx
+++ b/src/app/education/page.tsx
@@ -1,31 +1,50 @@
+import Hero1 from "@/components/blocks/hero1";
+
 export const metadata = {
   title: "Education | Next Standup",
-  description: "Curated resources for continuous learning.",
+  description: "Curated tutorials, docs, and videos to level-up your workflow.",
 };
 
 export default function EducationPage() {
   return (
-    <main className="mx-auto max-w-3xl space-y-6 p-4">
-      <h1 className="text-2xl font-semibold">Education</h1>
-      <p className="text-muted-foreground">
-        A curated list of external resources to sharpen your skills. We’ll keep
-        adding more links over time.
-      </p>
+    <main className="mx-auto max-w-3xl space-y-8 p-4">
+      {/* ─── Hero with very tight spacing ───────────────────────── */}
+      <Hero1
+        className="py-6 md:py-8" /* 👈 now truly compact */
+        badge="📚 Education"
+        heading="Master new skills"
+        description="Explore hand-picked articles, docs, and videos. Check back regularly for fresh material."
+        buttons={{
+          primary: { text: "Start learning", url: "#resources" },
+          secondary: {
+            text: "Suggest a link",
+            url: "https://github.com/robertplaut/next-standup/issues",
+          },
+        }}
+        image={{
+          src: "https://images.unsplash.com/photo-1516979187457-637abb4f9353?q=80&w=1740&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+          alt: "Stack of books illustrating learning",
+        }}
+      />
 
-      <section className="space-y-3">
-        <Resource
-          href="https://nextjs.org/learn"
-          label="Next.js Official Tutorial"
-        />
-        <Resource
-          href="https://tailwindcss.com/docs"
-          label="Tailwind CSS Documentation"
-        />
-        <Resource href="https://supabase.com/docs" label="Supabase Docs" />
-        <Resource
-          href="https://www.typescriptlang.org/docs/"
-          label="TypeScript Handbook"
-        />
+      {/* ─── Resource list ─────────────────────────────────────── */}
+      <section id="resources" className="space-y-6">
+        <h2 className="text-2xl font-semibold">Featured Resources</h2>
+        <ul className="space-y-3">
+          <Resource
+            href="https://nextjs.org/learn"
+            label="Next.js Official Tutorial"
+          />
+          <Resource
+            href="https://tailwindcss.com/docs"
+            label="Tailwind CSS Documentation"
+          />
+          <Resource href="https://supabase.com/docs" label="Supabase Docs" />
+          <Resource
+            href="https://www.typescriptlang.org/docs/"
+            label="TypeScript Handbook"
+          />
+        </ul>
       </section>
     </main>
   );
@@ -33,13 +52,15 @@ export default function EducationPage() {
 
 function Resource({ href, label }: { href: string; label: string }) {
   return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="block rounded border p-3 hover:bg-muted/50"
-    >
-      {label}
-    </a>
+    <li>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block rounded border p-3 hover:bg-muted/50"
+      >
+        {label}
+      </a>
+    </li>
   );
 }

--- a/src/components/blocks/hero1.tsx
+++ b/src/components/blocks/hero1.tsx
@@ -1,0 +1,71 @@
+import { ArrowRight, ArrowUpRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import clsx from "clsx";
+
+export interface Hero1Props {
+  badge?: string;
+  heading: string;
+  description: string;
+  buttons?: {
+    primary?: { text: string; url: string };
+    secondary?: { text: string; url: string };
+  };
+  image: { src: string; alt: string };
+  /** Utility classes for padding / background / etc. */
+  className?: string;
+}
+
+export default function Hero1({
+  badge,
+  heading,
+  description,
+  buttons,
+  image,
+  className = "py-20 lg:py-32", // ⬅️ default, but easily overridden
+}: Hero1Props) {
+  return (
+    <section className={clsx(className)}>
+      <div className="container">
+        <div className="grid items-center gap-8 lg:grid-cols-2">
+          {/* text col */}
+          <div className="flex flex-col items-center text-center lg:items-start lg:text-left">
+            {badge && (
+              <span className="inline-flex items-center gap-1 rounded border px-2 py-1 text-xs font-medium">
+                {badge}
+                <ArrowUpRight className="size-4" />
+              </span>
+            )}
+            <h1 className="my-6 text-pretty text-4xl font-bold lg:text-6xl">
+              {heading}
+            </h1>
+            <p className="text-muted-foreground mb-8 max-w-xl lg:text-xl">
+              {description}
+            </p>
+            <div className="flex w-full flex-col justify-center gap-2 sm:flex-row lg:justify-start">
+              {buttons?.primary && (
+                <Button asChild className="w-full sm:w-auto">
+                  <a href={buttons.primary.url}>{buttons.primary.text}</a>
+                </Button>
+              )}
+              {buttons?.secondary && (
+                <Button asChild variant="outline" className="w-full sm:w-auto">
+                  <a href={buttons.secondary.url}>
+                    {buttons.secondary.text}
+                    <ArrowRight className="ml-2 size-4" />
+                  </a>
+                </Button>
+              )}
+            </div>
+          </div>
+
+          {/* image col */}
+          <img
+            src={image.src}
+            alt={image.alt}
+            className="max-h-96 w-full rounded-md object-cover"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Description
Re-implements the Hero block using Tailwind-styled span (no Badge) to avoid shadcn install issues.

### Key Changes
- `components/blocks/hero1.tsx`: handcrafted component, no external deps.

### How to Test
1. `npm run dev`, open `/education`.
2. Hero section renders with pill label, heading, description, buttons, and placeholder image.
3. Responsive layout intact.